### PR TITLE
Address values are converted to hex strings instead of integer strings

### DIFF
--- a/src/main/java/com/cegeka/tetherj/crypto/CryptoUtil.java
+++ b/src/main/java/com/cegeka/tetherj/crypto/CryptoUtil.java
@@ -114,4 +114,41 @@ public class CryptoUtil {
         }
         throw new IllegalArgumentException("Invalid hex character");
     }
+
+    /**
+     * Get the address as short string.
+     * @param ethereumAddress Address as big integer.
+     * @return short string represent 1f21c...
+     */
+    public static String bigIntegerToAddress(BigInteger ethereumAddress) {
+        String address = ethereumAddress.toString(16);
+
+        while (address.length() < 40) {
+            address = "0" + address;
+        }
+
+        if (!isValidAddress(address)) {
+            throw new Error("not an address");
+        }
+
+        return "0x" + address;
+    }
+
+    /**
+     * Returns true if address is a valid ethereum address.
+     * @param address to check
+     * @return true if valid
+     */
+    public static boolean isValidAddress(byte[] address) {
+        return address != null && address.length == 20;
+    }
+
+    /**
+     * Returns true if address is a valid ethereum address.
+     * @param address to check
+     * @return true if valid
+     */
+    public static boolean isValidAddress(String address) {
+        return address != null && address.length() == 40;
+    }
 }

--- a/src/main/java/org/ethereum/core/CallTransaction.java
+++ b/src/main/java/org/ethereum/core/CallTransaction.java
@@ -446,6 +446,12 @@ public class CallTransaction {
         }
 
         @Override
+        public Object decode(byte[] encoded, int offset) {
+            BigInteger addressAsInt = (BigInteger) super.decode(encoded, offset);
+            return CryptoUtil.bigIntegerToAddress(addressAsInt);
+        }
+
+        @Override
         public String toString() {
             return "String";
         }


### PR DESCRIPTION
Tether contract getters now directly decode addresses to hex strings instead of big integer (existing applications will have to be adapted to this new behaviour, but it's the right one and should have been like this from the start)